### PR TITLE
fix typo on 'How to Contribute' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ New to open source? No worries!
 1. **Fork this repository.**
 2. **Clone your forked repository to your local machine.**
 3. **Create a new branch for your contribution.**
-4. **Add your C program or make changes.**
+4. **Add your Python program or make changes.**
 5. **Commit your changes with clear comments.**
 6. **Push your changes to your forked repository.**
 7. **Submit a pull request.**


### PR DESCRIPTION
Fixed typo on 'How to Contribute' section.
step 4: C → Python

<img width="513" alt="Screenshot 2023-10-19 at 5 47 17 PM" src="https://github.com/KALIIOWORK/basic_python_programs/assets/54586757/fd5d681d-4633-4553-bce9-0e972319f513">
